### PR TITLE
fix: pin sync-api dependencies to minimum versions

### DIFF
--- a/sync-api/requirements.txt
+++ b/sync-api/requirements.txt
@@ -1,7 +1,7 @@
-fastapi
-uvicorn[standard]
-httpx
-spotipy
-python-multipart
-aiofiles
-pydantic
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0
+httpx>=0.27.0
+spotipy>=2.24.0
+python-multipart>=0.0.9
+aiofiles>=24.1.0
+pydantic>=2.7.0


### PR DESCRIPTION
## Summary
Pins all dependencies in `sync-api/requirements.txt` to minimum versions using `>=` constraints, closing #37.

## Problem
Previously, `sync-api/requirements.txt` had zero version constraints — all packages were listed as bare names. This made builds non-reproducible and created risk of accidentally pulling breaking changes or vulnerable releases.

## Solution
All packages now use minimum-version pins (matching pattern in `sync-worker/requirements.txt`):
- fastapi>=0.115.0
- uvicorn[standard]>=0.30.0
- httpx>=0.27.0
- spotipy>=2.24.0
- python-multipart>=0.0.9
- aiofiles>=24.1.0
- pydantic>=2.7.0

## Testing
- [ ] Clean build: `docker compose build --no-cache sync-api`
- [ ] Stack starts: `docker compose up -d`
- [ ] API health check passes: `curl http://localhost:8402/health`

Closes #37

🤖 Generated by CTO Audit Agent