### PR TITLE
chore: drop obsolete compose version key + stray = file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   sync-api:
     build:


### PR DESCRIPTION
Minor cleanup surfaced while verifying the self-heal fix (#43):

- **Remove `version: '3.8'`** from `docker-compose.yml`. Compose v2 ignores the key and prints `the attribute \`version\` is obsolete` on every call — this warning now shows up in the self-heal restart path in `sls-monitor.log`.
- **Delete the empty `=` file** committed accidentally via a `> =` redirect typo.

No functional change; `docker-compose config` still validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)